### PR TITLE
Fix JSON cannot be loaded with HTTP Basic Auth

### DIFF
--- a/src/utils/requestState.js
+++ b/src/utils/requestState.js
@@ -5,7 +5,10 @@ const normalizeURL = require('./normalizeURL')
 module.exports = async function(url) {
 
 	const endpoint = `${ normalizeURL(url) }.json`
-	const response = await fetch(endpoint)
+	const request = new Request(endpoint, {
+		credentials: 'same-origin'
+	})
+	const response = await fetch(request)
 
 	if (response.ok===false) throw new Error('Failed to request components data')
 


### PR DESCRIPTION
When the project is hosted on a server that requests a HTTP Basic Auth the file `index.html.json` cannot be loaded.

The reason is that the credentials aren’t passed to the Request. Setting the 'same-origin' policy for the Request will automatically add the correct `Authorization`-header.

FYI @marclindemann